### PR TITLE
adjusted JavaDoc content extraction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,11 @@ jobs:
       artifact: ${{ steps.properties.outputs.artifact }}
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3.6.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'corretto'
 
       # Check out current repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
       version: ${{ steps.properties.outputs.version }}
     steps:
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3.6.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'corretto'
 
       # Check out current repository

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ This document provides a high-level view of the changes introduced by release.
 === 0.1.3
 
 - Align with the latest version of the AsciiDoc plugin for IntelliJ 0.37.39+ (#3)
+- Enhanced JavaDoc content extraction for latest IntelliJ IDEA (#1)
 
 === 0.1.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,11 @@ allprojects {
 }
 
 intellij {
-  version = 'IC-2021.3.2'
+  version = 'IC-2022.2'
   pluginName = 'asciidoclet-intellij-plugin'
   updateSinceUntilBuild = false
   plugins = [
-    'PsiViewer:213-SNAPSHOT', // used for debugging
+    'PsiViewer:222-SNAPSHOT', // used for debugging
     'org.asciidoctor.intellij.asciidoc:0.37.54', // used as a base for rendering AsciiDoc
     'java' // used to override Java
   ]
@@ -110,6 +110,11 @@ sourceSets {
       exclude('META-INF/description.html')
     }
   }
+}
+
+java {
+  targetCompatibility = "11"
+  sourceCompatibility = "11"
 }
 
 compileJava {

--- a/src/main/java/org/asciidoc/intellij/asciidoclet/javadoc/AsciidocletJavaDocInfoGenerator.java
+++ b/src/main/java/org/asciidoc/intellij/asciidoclet/javadoc/AsciidocletJavaDocInfoGenerator.java
@@ -76,7 +76,7 @@ public class AsciidocletJavaDocInfoGenerator extends JavaDocInfoGenerator {
         // no Javadoc content found
         return html;
       }
-      int end = html.lastIndexOf(END);
+      int end = html.indexOf(END, start);
       // in some places the IntelliJ code adds a <p> right before the div, remove that as well.
       //noinspection StringOperationCanBeSimplified
       if (html.substring(end - 3, end).equals("<p>")) {
@@ -88,7 +88,7 @@ public class AsciidocletJavaDocInfoGenerator extends JavaDocInfoGenerator {
 
       // remove indentation spaces at beginning of the line
       int c = 0;
-      while (content.length() > c && content.charAt(c) == ' ') {
+      while (content.length() > c && isSkipableWhitespace(content.charAt(c))) {
         c++;
       }
       content = content.replaceAll("\n" + content.substring(0, c), "\n");
@@ -145,5 +145,8 @@ public class AsciidocletJavaDocInfoGenerator extends JavaDocInfoGenerator {
     return html;
   }
 
+  private boolean isSkipableWhitespace(char character) {
+    return character == ' ' || character == '\t';
+  }
 
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing documents:

If someone is using DIV tags within the existing JavaDoc, then the Asciidoc conversion stops a the first closing div tag.

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If you're adding or changing functionality:
- [ ] All tests are passing: https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html
- [ ] New/updated tests are included

**Other information:**

I am on IntelliJ IDEA 2022.1 EAP (221.5080.9) and I faced two issues:

1) From the JavaDoc, the whitespace-prefix detection did not take any "tab" character into account and therefore did not correctly remove that prefix from the source. Not sure why my IDE added that tab at all, as I am using "spaces".

2) The new Help content generated by the IDE now contains other div tags and searching for the last closing div tag to find the help boundaries is not enough any longer. I changed it to use the first closing div after the start.
